### PR TITLE
Use the new suspend and resume steps from upstream

### DIFF
--- a/gcp-instance-state-enforcer/gcp-instance-state-enforcer.yaml
+++ b/gcp-instance-state-enforcer/gcp-instance-state-enforcer.yaml
@@ -108,20 +108,18 @@ steps:
 - name: resume-instances
   when: ${outputs.'identify-instance-states'.to_resume != []}
   dependsOn: identify-instance-states
-  image: relaysh/gcp-step-instance-start
+  image: relaysh/gcp-step-instance-resume
   spec:
     google: *google
     instances: ${outputs.'identify-instance-states'.to_resume}
-  inputFile: https://raw.githubusercontent.com/puppetlabs/support-relay_workflows/main/gcp-instance-state-enforcer/gcp-instance-resume.py
 
 - name: suspend-instances
   when: ${outputs.'identify-instance-states'.to_suspend != []}
   dependsOn: identify-instance-states
-  image: relaysh/gcp-step-instance-stop
+  image: relaysh/gcp-step-instance-suspend
   spec:
     google: *google
     instances: ${outputs.'identify-instance-states'.to_suspend}
-  inputFile: https://raw.githubusercontent.com/puppetlabs/support-relay_workflows/main/gcp-instance-state-enforcer/gcp-instance-suspend.py
 
 - name: slack-notification
   image: relaysh/slack-step-message-send


### PR DESCRIPTION
Prior to this commit, we were overriding the inputFile on the start and
stop images to do suspend and resume operations. The upstream steps now
provide suspend and resume operations that we can use instead of
overriding them. This commit updates the workflow to use the new suspend
and resume images instead of the inputFile override.

Resolves #13 